### PR TITLE
LRDOCS-3721 Start document library file URLs at root context '/'.

### DIFF
--- a/develop/tutorials/articles/100-tooling/02-liferay-ide/02-creating-a-liferay-workspace-with-liferay-ide.markdown
+++ b/develop/tutorials/articles/100-tooling/02-liferay-ide/02-creating-a-liferay-workspace-with-liferay-ide.markdown
@@ -9,13 +9,13 @@ Workspaces, visit its dedicated
 [tutorial section](/develop/tutorials/-/knowledge_base/7-0/liferay-workspace).
 
 <div class="video-link">
-<img src="https://dev-uat.liferay.com/webdav/guest/document_library/Develop-videos/Thumbnails/vid-ide-thumbnail.png"/ >
+<img src="/webdav/guest/document_library/Develop-videos/Thumbnails/vid-ide-thumbnail.png"/ >
 </div>
 
 <div class="video-tag" data-name="Getting Started with Liferay IDE">
   <video width="100%" height="100%" controls>
-    <source src="https://dev.liferay.com/webdav/guest/document_library/Develop-videos/getting-started-with-liferay-ide.mp4" type="video/mp4">
-    <source src="https://dev.liferay.com/webdav/guest/document_library/Develop-videos/getting-started-with-liferay-ide.webm" type="video/webm">
+    <source src="/webdav/guest/document_library/Develop-videos/getting-started-with-liferay-ide.mp4" type="video/mp4">
+    <source src="/webdav/guest/document_library/Develop-videos/getting-started-with-liferay-ide.webm" type="video/webm">
     Your browser does not support HTML5 video.
   </video>
 </div>

--- a/discover/portal/articles/02-web-experience-management/02-creating-web-content/02-designing-uniform-content.markdown
+++ b/discover/portal/articles/02-web-experience-management/02-creating-web-content/02-designing-uniform-content.markdown
@@ -10,13 +10,13 @@ they should. And sometimes, content is published that should never have seen the
 light of day.
 
 <div class="video-link">
-<img src="https://dev.liferay.com/webdav/guest/document_library/User-admin-videos/Thumbnails/vid-struc-temp-thumbnail.png"/ >
+<img src="/webdav/guest/document_library/User-admin-videos/Thumbnails/vid-struc-temp-thumbnail.png"/ >
 </div>
 
 <div class="video-tag" data-name="Creating Content with Structures and Templates">
   <video width="100%" height="100%" controls>
-    <source src="https://dev.liferay.com/webdav/guest/document_library/User-admin-videos/creating-content-with-structures-and-templates.mp4" type="video/mp4">
-    <source src="https://dev.liferay.com/webdav/guest/document_library/User-admin-videos/creating-content-with-structures-and-templates.webm" type="video/webm">
+    <source src="/webdav/guest/document_library/User-admin-videos/creating-content-with-structures-and-templates.mp4" type="video/mp4">
+    <source src="/webdav/guest/document_library/User-admin-videos/creating-content-with-structures-and-templates.webm" type="video/webm">
     Your browser does not support HTML5 video.
   </video>
 </div>


### PR DESCRIPTION
Hey Mike,

They don't render right.

Note, I made this one change to start the URLs at / instead of https://dev-uat/. But I tested it before this change too. Regardless, there's a rendering problem.