### PR TITLE
LRDOCS-3721 Close img tag and use relative image path from liferay-docs

### DIFF
--- a/develop/tutorials/articles/100-tooling/02-liferay-ide/02-creating-a-liferay-workspace-with-liferay-ide.markdown
+++ b/develop/tutorials/articles/100-tooling/02-liferay-ide/02-creating-a-liferay-workspace-with-liferay-ide.markdown
@@ -9,7 +9,7 @@ Workspaces, visit its dedicated
 [tutorial section](/develop/tutorials/-/knowledge_base/7-0/liferay-workspace).
 
 <div class="video-link">
-<img src="http://dev-uat.liferay.com/webdav/guest/document_library/Develop-videos/Thumbnails/vid-ide-thumbnail.png" alt="video-thumbnail">
+<img src="../../../images/vid-ide-thumbnail.png" alt="video-thumbnail"/>
 </div>
 
 Before creating your Liferay Workspace, you should understand the available

--- a/discover/portal/articles/02-web-experience-management/02-creating-web-content/02-designing-uniform-content.markdown
+++ b/discover/portal/articles/02-web-experience-management/02-creating-web-content/02-designing-uniform-content.markdown
@@ -10,7 +10,7 @@ they should. And sometimes, content is published that should never have seen the
 light of day.
 
 <div class="video-link">
-<img src="/webdav/guest/document_library/User-admin-videos/Thumbnails/vid-struc-temp-thumbnail.png" alt="video thumbnail">
+<img alt="video thumbnail" src="../../../images/vid-struc-temp-thumbnail.png" />
 </div>
 
 Thankfully, Liferay WCM helps you handle all of those situations. You can use


### PR DESCRIPTION
Close img tag with a slash before the ending angle bracket. Use relative path to image file in liferay-docs repo.